### PR TITLE
Updates Travis config to tag release prior to deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,10 @@ script:
 before_deploy:
   - carthage build --no-skip-current
   - carthage archive GatheredKit
+  # Based on https://docs.travis-ci.com/user/deployment/releases/ to automatically tag, but modified to use the merger's credentials
+  - git config --local user.name "$(git log -1 --pretty=format:'%an')"
+  - git config --local user.email "$(git log -1 --pretty=format:'%ae')"
+  - git tag "v$(defaults read "$(pwd)/Source/Info.plist" CFBundleShortVersionString)"
 
 deploy:
   - provider: releases
@@ -29,13 +33,13 @@ deploy:
     file: GatheredKit.framework.zip
     skip_cleanup: true
     on:
-      tag: true
+      tags: true
       repo: JosephDuffy/GatheredKit
   - provider: script
     script: pod trunk push
     skip_cleanup: true
     on:
-      tag: true
+      tags: true
       repo: JosephDuffy/GatheredKit
 
 env:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![GatheredKit](https://josephduffy.github.io/GatheredKit/img/banner.png)
 
-[![Build Status](https://api.travis-ci.com/JosephDuffy/GatheredKit.svg)](https://travis-ci./JosephDuffy/GatheredKit)
+[![Build Status](https://api.travis-ci.com/JosephDuffy/GatheredKit.svg)](https://travis-ci.com/JosephDuffy/GatheredKit)
 [![Documentation](https://josephduffy.github.io/GatheredKit/badge.svg)](https://josephduffy.github.io/GatheredKit/)
 [![Carthage Compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
 [![CocoaPods Compatible](https://img.shields.io/cocoapods/v/GatheredKit.svg)](https://cocoapods.org/pods/GatheredKit)


### PR DESCRIPTION
This ensures the correct version is shown on the releases page

Also fixes the name of the `tags` parameter of `on` in the `deploy`; previously it was `tag`
Updates README (again 🤦‍♂️)