### PR TITLE
Remove `brew update` from `before_install` stage of Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ cache:
     - Carthage
 
 before_install:
-  - brew update
   - brew outdated carthage || brew upgrade carthage
 
 install:


### PR DESCRIPTION
This is no longer required. Previously it was required to install a version of Carthage that supported to `--archive` flag